### PR TITLE
make ElementalSystem names unique

### DIFF
--- a/quara/objects/elemental_system.py
+++ b/quara/objects/elemental_system.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from quara.objects import matrix_basis
 from quara.objects.matrix_basis import MatrixBasis
 
@@ -5,8 +7,15 @@ from quara.objects.matrix_basis import MatrixBasis
 class ElementalSystem:
     """個々の量子系を記述するためのクラス"""
 
+    __esys_names: Dict[str, "ElementalSystem"] = {}
+
+    @classmethod
+    def esys_names(cls):
+        return list(cls.__esys_names.keys())
+
     def __init__(self, name: str, basis: MatrixBasis):
         self._name: str = name
+        self.__class__._regist_esys_name(self)
         # system_idを持たせなくても同値ではなく同一インスタンスであるかどうかの判定はisで可能だが、
         # system_idで持たせておくとうっかり同値判定（==）で比較しても異なる値として判断されるので、
         # とりあえず持たせておく
@@ -15,8 +24,18 @@ class ElementalSystem:
         # self._computational_basis: MatrixBasis = None  # TODO
         self._hemirtian_basis: MatrixBasis = basis
 
+    @classmethod
+    def _regist_esys_name(cls, new_elemental_system: "ElementalSystem"):
+        name = new_elemental_system.name
+        if name in cls.__esys_names:
+            raise ValueError(
+                f"An ElementalSystem with the name '{name}' already exists."
+            )
+
+        cls.__esys_names[name] = new_elemental_system
+
     @property
-    def name(self):
+    def name(self):  # read only
         return self._name
 
     @property


### PR DESCRIPTION
Raises an exception if an ElementalSystem with the same name already exists.
```
>>> import quara.objects.elemental_system as esys
>>> from quara.objects.elemental_system import get_with_normalized_pauli_basis
>>> a1 = get_with_normalized_pauli_basis("A")
>>> a2 = get_with_normalized_pauli_basis("A")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/furuki/project/survey/workspace/quara/quara/objects/elemental_system.py", line 67, in get_with_normalized_pauli_basis
    system = ElementalSystem(name, basis)
  File "/Users/furuki/project/survey/workspace/quara/quara/objects/elemental_system.py", line 18, in __init__
    self.__class__._regist_esys_name(self)
  File "/Users/furuki/project/survey/workspace/quara/quara/objects/elemental_system.py", line 32, in _regist_esys_name
    f"An ElementalSystem with the name '{name}' already exists."
ValueError: An ElementalSystem with the name 'A' already exists.
```

List the names of existing ElementalSystems
```
>>> import quara.objects.elemental_system as esys
>>> from quara.objects.elemental_system import get_with_normalized_pauli_basis
>>> a = get_with_normalized_pauli_basis("A")
>>> b = get_with_normalized_pauli_basis("B")
>>> 
>>> esys.ElementalSystem.esys_names()
['A', 'B']
```