### PR TITLE
add; store system log after ci test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,14 @@ jobs:
             nohup quilc -S > /tmp/artifacts/quilc.log &
             . venv/bin/activate
             pytest -rfs -m "not threequbit and not twoqutrit and not qmpt_twoqubit and not qmpt_onequtrit" --durations=0 --junit-xml=test-results/pytest.xml
+      - run:
+          name: Read Log
+          when: always
+          command: |
+            if [ ! -d /tmp/artifacts ]; then mkdir /tmp/artifacts; fi
+            sudo apt install lsof
+            sudo lsof
+            sudo lsof > /tmp/artifacts/lsof.log
       - store_test_results:
             path: test-results
       - store_artifacts:
@@ -75,6 +83,14 @@ jobs:
             nohup quilc -S > /tmp/artifacts/quilc.log &
             . venv/bin/activate
             pytest -rfs -m "not threequbit and not twoqutrit and not qmpt_twoqubit and not qmpt_onequtrit" --durations=0 --junit-xml=test-results/pytest.xml
+      - run:
+          name: Read Log
+          when: always
+          command: |
+            if [ ! -d /tmp/artifacts ]; then mkdir /tmp/artifacts; fi
+            sudo apt install lsof
+            sudo lsof
+            sudo lsof > /tmp/artifacts/lsof.log
       - store_test_results:
             path: test-results
       - store_artifacts:
@@ -110,6 +126,14 @@ jobs:
             nohup quilc -S > /tmp/artifacts/quilc.log &
             . venv/bin/activate
             pytest -rfs -m "not threequbit and not twoqutrit and not qmpt_twoqubit and not qmpt_onequtrit" --durations=0 --junit-xml=test-results/pytest.xml
+      - run:
+          name: Read Log
+          when: always
+          command: |
+            if [ ! -d /tmp/artifacts ]; then mkdir /tmp/artifacts; fi
+            sudo apt install lsof
+            sudo lsof
+            sudo lsof > /tmp/artifacts/lsof.log
       - store_test_results:
             path: test-results
       - store_artifacts:
@@ -145,6 +169,14 @@ jobs:
             nohup quilc -S > /tmp/artifacts/quilc.log &
             . venv/bin/activate
             pytest -rfs -m "not threequbit and not twoqutrit and not qmpt_twoqubit and not qmpt_onequtrit" --durations=0 -o "norecursedirs=quara/interface" --junit-xml=test-results/pytest.xml
+      - run:
+          name: Read Log
+          when: always
+          command: |
+            if [ ! -d /tmp/artifacts ]; then mkdir /tmp/artifacts; fi
+            sudo apt install lsof
+            sudo lsof
+            sudo lsof > /tmp/artifacts/lsof.log
       - store_test_results:
             path: test-results
       - store_artifacts:


### PR DESCRIPTION
This change will enable CI pipeline to store outputs of `lsof` command after tests for further inspection in docker container.